### PR TITLE
Limit CI run environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
-          - ubuntu-latest # Don't use this in production!
+          - ubuntu-22.04
         python:
           - "3.9"
           - "3.10"


### PR DESCRIPTION
We should only support Python 3.9 onwards and set ci to run on ubuntu-22.04. This will simplify what we need to support moving forward.