### PR TITLE
chore: Remove non-prod context, parse security grp id in context

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,26 +5,23 @@ from stack.bde_fdw_rds_stack import Application
 
 app = cdk.App()
 
-# Parse user provided context for environment parameter (i.e. prod / non-prod)
-environment = app.node.try_get_context("environment")
-
-if environment not in ("prod", "non-prod"):
-    raise ValueError(f"Invalid deployment environment: “{environment}”. Available options: prod / non-prod")
-
 # Instantiate additional context specified in cdk.json based on environment type
-available_environments = app.node.try_get_context("available_environments")
-deployment_environment = available_environments.get(environment)
-aws_account = deployment_environment.get("account_id")
-aws_region = deployment_environment.get("region")
-aws_vpc_id = deployment_environment.get("vpc_id")
-aws_subnets = deployment_environment.get("subnets")
+environment = app.node.try_get_context("prod_env")
 
-rds_fdw_instance_type = deployment_environment.get("rds_fdw_instance_type")
+aws_account = environment.get("account_id")
+aws_region = environment.get("region")
+aws_vpc_id = environment.get("vpc_id")
+aws_subnets = environment.get("subnets")
+
+rds_fdw_instance_type = environment.get("rds_fdw_instance_type")
 
 cdk_env = cdk.Environment(account=aws_account, region=aws_region)
 
-bde_host_name = deployment_environment.get("bde_host_name")
-bde_analytics_user_secret = deployment_environment.get("bde_analytics_user_secret")
+bde_host_name = environment.get("bde_host_name")
+bde_analytics_user_secret = environment.get("bde_analytics_user_secret")
+
+bde_rds_security_group = environment.get("bde_rds_security_group")
+bastion_host_security_group = environment.get("bastion_host_security_group")
 
 
 Application(
@@ -37,6 +34,8 @@ Application(
     rds_fdw_instance_type=rds_fdw_instance_type,
     bde_host_name=bde_host_name,
     bde_analytics_user_secret=bde_analytics_user_secret,
+    bde_rds_security_group=bde_rds_security_group,
+    bastion_host_security_group=bastion_host_security_group,
 )
 
 

--- a/cdk.json
+++ b/cdk.json
@@ -21,29 +21,16 @@
     "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
     "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
     "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
-    "available_environments": {
-      "prod": {
-        "account_id": "167241006131",
-        "region": "ap-southeast-2",
-        "vpc_id": "vpc-23487b47",
-        "subnets": ["subnet-51844336", "subnet-a6a85fef", "subnet-98f2a8c1"],
-        "rds_fdw_instance_type": { "class": "BURSTABLE3", "size": "SMALL" },
-        "bde_host": "bde-processor-db.cnta12almaey.ap-southeast-2.rds.amazonaws.com",
-        "bde_analytics_user_secret": "prod/bde/fdw_analytics"
-      },
-      "non-prod": {
-        "account_id": "750833841965",
-        "region": "ap-southeast-2",
-        "vpc_id": "vpc-0fb6a7defd5693aa8",
-        "subnets": [
-          "subnet-06ff7dbe6da04cdde",
-          "subnet-04865c78665fdf874",
-          "subnet-0e90f0bcba6cb7453"
-        ],
-        "rds_fdw_instance_type": { "class": "BURSTABLE3", "size": "MICRO" },
-        "bde_host": "bde-processor-db-test.cnta12almaey.ap-southeast-2.rds.amazonaws.com",
-        "bde_analytics_user_secret": "prod/bde/fdw_analytics"
-      }
+    "prod_env": {
+      "account_id": "167241006131",
+      "region": "ap-southeast-2",
+      "vpc_id": "vpc-23487b47",
+      "subnets": ["subnet-51844336", "subnet-a6a85fef", "subnet-98f2a8c1"],
+      "rds_fdw_instance_type": { "class": "BURSTABLE3", "size": "SMALL" },
+      "bde_host_name": "bde-processor-db.cnta12almaey.ap-southeast-2.rds.amazonaws.com",
+      "bde_analytics_user_secret": "prod/bde/fdw_analytics",
+      "bde_rds_security_group": "sg-09ff7858b47cce6d7",
+      "bastion_host_security_group": "sg-0d9a5d450c9125a28"
     }
   }
 }


### PR DESCRIPTION
The legacy nature of the bde has prevented a proper ci setup. Due to cross account networking complexity, deploying this cdk in non-prod is not possible (not without setting up bespoke vpc peering / sharing / private gateway). This commit removes non-prod environment variables provided in context that was previously used for testing.